### PR TITLE
ISA urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ import { QuantelGateway, Q } from 'quantel-gateway-client'
 const quantelClient = new QuantelGateway()
 await quantelCient.init(
 	'quantel.gateway.url:port',
-	'quantel.isa.url',
-	undefined,
+	'quantel.isa.url', // or ['quantel.masterISA.url', 'quantel.slaveISA.url, ...]
 	'default',
 	serverID
 )

--- a/src/quantelGateway.ts
+++ b/src/quantelGateway.ts
@@ -129,7 +129,7 @@ export class QuantelGateway extends EventEmitter {
 	 */
 	public monitorServerStatus(
 		callbackOnStatusChange: (connected: boolean, errorMessage: string | null) => void
-	) {
+	): void {
 		const getServerStatus = async (): Promise<string | null> => {
 			try {
 				this._connected = false
@@ -184,7 +184,7 @@ export class QuantelGateway extends EventEmitter {
 				return `Error when monitoring status: ${(e && e.message) || e.toString()}`
 			}
 		}
-		const checkServerStatus = () => {
+		const checkServerStatus = (): void => {
 			getServerStatus()
 				.then((statusMessage) => {
 					if (statusMessage !== this._statusMessage) {
@@ -508,7 +508,7 @@ export class QuantelGateway extends EventEmitter {
 	 * Set the ports that are monitored for changes.
 	 * @param monitorPorts Dictionary of ports monitored for status change.
 	 */
-	public setMonitoredPorts(monitorPorts: MonitorPorts) {
+	public setMonitoredPorts(monitorPorts: MonitorPorts): void {
 		this._monitorPorts = monitorPorts
 	}
 
@@ -517,7 +517,7 @@ export class QuantelGateway extends EventEmitter {
 	 * If running in Docker configured to auto-restart, calling this method will
 	 * cause the gateway to automatically restart.
 	 */
-	public async kill() {
+	public async kill(): void {
 		return this.sendBase('POST', 'kill/me/if/you/are/sure')
 	}
 

--- a/src/quantelTypes.ts
+++ b/src/quantelTypes.ts
@@ -399,7 +399,7 @@ export interface ConnectionDetails {
 	isaIOR: string
 	/** Location of the attached ISA manager. */
 	href: string
-	/** List of alternative ISA managers, e.g. master and backup. */
+	/** List of alternative ISA managers, e.g. master and slave(s). */
 	refs: string[]
 	/** Incrementing round robim counter used to select the next ISA manager on failure. */
 	robin: number


### PR DESCRIPTION
This PR changes how the ISA urls are stored and used.

The reason for this is for a consumer to be able to determine if a quantel-gatway can be used (is is connected to the right ISA:s) or not.

~This change is a refactoring only, and should not affect any external dependants.~
This PR is a breaking change, as the URL:s are now used and stored as a `string[]`, no differing between a master and a backup anymore (since master/backup isn't really a Quantel semantic, there are only a pool of ISA's, one of which will be the master).

Todo:
- [ ] Test that it works