### PR TITLE
fix: dont require serverId

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,11 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"got": "^11.5.2",
-		"underscore": "^1.9.1"
+		"got": "^11.5.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^25.2.1",
 		"@types/node": "^10.17.21",
-		"@types/underscore": "^1.9.2",
 		"@typescript-eslint/eslint-plugin": "^2.28.0",
 		"@typescript-eslint/parser": "^2.28.0",
 		"codecov": "^3.6.5",

--- a/src/quantelGateway.ts
+++ b/src/quantelGateway.ts
@@ -77,8 +77,12 @@ export class QuantelGateway extends EventEmitter {
 		// const zone = _.find(zones, zone => zone.zoneName === this._zoneId)
 		// if (!zone) throw new Error(`Zone ${this._zoneId} not found!`)
 
-		const server = await this.getServer()
-		if (!server) throw new Error(`Server ${this._serverId} not found!`)
+		// If the server is not set, skip this check.
+		// (In some cases, the consumer might not want to provide a serverId (like when only we only want to search, never copy))
+		if (this._serverId !== 0) {
+			const server = await this.getServer()
+			if (!server) throw new Error(`Server ${this._serverId} not found!`)
+		}
 
 		this._initialized = true
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,11 +710,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/underscore@^1.9.2":
-  version "1.10.22"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.10.22.tgz#8e0a134a2df0afe8da24bcf006e7f94925a3e15f"
-  integrity sha512-fiJulOOmc747q+mZwBtLyBu6yBX2uI4biuQ1Y3JvcU7YjmdOEOracUXTiET/PAWI2hhoUH1t4HbwJj42YEnbkg==
-
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -6012,11 +6007,6 @@ uglify-js@^3.1.4:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.1.tgz#dd14767eb7150de97f2573a5ff210db14fffe4ad"
   integrity sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==
-
-underscore@^1.9.1:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR solves an edge-case I'm having in Package Manager.

My use case: I would like to use the library for only searching for clips and see statuses of servers etc. In this case I _don't_ want to provide a serverId.

After this fix, I can send in serverId=0 and it'll work just fine for me.

I suppose a proper long-term solution would be to split the QuantelGateway class into multiple classes, where the basic ones only supports the zone-related functions, etc.. But I think this is should be good enough for now.